### PR TITLE
change to make it more configurable

### DIFF
--- a/src/test/scala/com/ubirch/simulations/SendUPPAproxRateSecondsSimulation.scala
+++ b/src/test/scala/com/ubirch/simulations/SendUPPAproxRateSecondsSimulation.scala
@@ -8,13 +8,17 @@ import scala.language.postfixOps
 
 class SendUPPAproxRateSecondsSimulation
   extends Simulation
-  with SendUPP
-  with Protocols
-  with ConfigBase {
+    with SendUPP
+    with Protocols
+    with ConfigBase {
 
   val numberOfUsers: Int = conf.getInt("sendUPPAproxRateSecondsSimulation.numberOfUsers")
   val duringValue: Int = conf.getInt("sendUPPAproxRateSecondsSimulation.duringValue")
   val devices: List[String] = conf.getString("simulationDevices").split(",").toList.filter(_.nonEmpty)
+
+  val rps: Int = conf.getInt("sendUPPAproxRateSecondsSimulation.rps")
+  val rampUp: Int = conf.getInt("sendUPPAproxRateSecondsSimulation.rampup")
+  val length: Int = conf.getInt("sendUPPAproxRateSecondsSimulation.length")
 
   setUp(
     sendScenario(devices)
@@ -23,6 +27,11 @@ class SendUPPAproxRateSecondsSimulation
           //if set to 14, it will send 14 messages per second
           .during(duringValue seconds)
       )
+      .throttle(
+        reachRps(rps) in (rampUp seconds),
+        holdFor(length seconds),
+      )
+
   ).protocols(niomonProtocol)
 
 }


### PR DESCRIPTION
sendUPPAproxRateSecondsSimulation {
  numberOfUsers = 1000 //This can be thought of as req/s. The result can be seen as the mean req/s in the gatling report that is
  //outputed in the console
  duringValue = 1200 //Seconds. This can be thought of as the duration of the simulation.

  rps = 100
  rampup = 10
  length = 1200
}
